### PR TITLE
DM-3638 Fix RangeField's handling of min > max

### DIFF
--- a/python/lsst/pex/config/rangeField.py
+++ b/python/lsst/pex/config/rangeField.py
@@ -45,8 +45,12 @@ class RangeField(Field):
         if min is None and max is None:
             raise ValueError("min and max cannot both be None")
 
-        if min is not None and max is not None and min > max:
-            swap(min, max)
+        if min is not None and max is not None:
+            if min > max:
+                raise ValueError("min = %s > %s = max" % (min, max))
+            elif min == max and not (inclusiveMin and inclusiveMax):
+                raise ValueError("min = max = %s and min and max not both inclusive" % (min,))
+
         self.min = min
         self.max = max
 


### PR DESCRIPTION
RangeField tried to swap min, max values if min > max
but the attempt used an invalid technique.
I removed that attempt and raise ValueError if min > max,
with equality allowed if both ends are inclusive.
I updated tests/config.py to check this new behavior
and also to test RangeField's checking of default values.