### PR TITLE
Fix `ConfigDict`'s handling of unicode keys

### DIFF
--- a/python/lsst/pex/config/configDictField.py
+++ b/python/lsst/pex/config/configDictField.py
@@ -23,7 +23,7 @@ from __future__ import print_function
 
 import traceback
 
-from .config import Config, FieldValidationError, _typeStr, _joinNamePath
+from .config import Config, FieldValidationError, _autocast, _typeStr, _joinNamePath
 from .dictField import Dict, DictField
 from .comparison import compareConfigs, compareScalars, getComparisonName
 
@@ -48,6 +48,7 @@ class ConfigDict(Dict):
             raise FieldValidationError(self._field, self._config, msg)
 
         # validate keytype
+        k = _autocast(k, self._field.keytype)
         if type(k) != self._field.keytype:
             msg = "Key %r is of type %s, expected type %s" % \
                 (k, _typeStr(k), _typeStr(self._field.keytype))

--- a/tests/configDictField.py
+++ b/tests/configDictField.py
@@ -79,7 +79,7 @@ class ConfigDictFieldTest(unittest.TestCase):
         self.assertRaises(pexConfig.FieldValidationError, setattr, c, "d1", {"a": 0})
         self.assertRaises(pexConfig.FieldValidationError, setattr, c, "d1", [1.2, 3, 4])
         c.d1 = None
-        c.d1 = {"a": Config1, "b": Config1()}
+        c.d1 = {"a": Config1, u"b": Config1()}
 
     def testValidate(self):
         c = Config2()

--- a/tests/dictField.py
+++ b/tests/dictField.py
@@ -81,7 +81,7 @@ class DictFieldTest(unittest.TestCase):
         c.d4 = d
         self.assertEqual(c.d4, d)
         c.d4["a"] = 12
-        c.d4["b"] = "three"
+        c.d4[u"b"] = "three"
         c.d4["c"] = None
         self.assertEqual(c.d4["a"], 12)
         self.assertEqual(c.d4["b"], "three")


### PR DESCRIPTION
Make `ConfigDict.__setitem__` call `_autocast` before checking the key type, just like `Dict` does. Add a unicode key in the unit test for each so that this is tested (and I confirmed the fix by commenting out the call to `_autocast` in both dict classes, and two tests failed.

This solves a problem that pybind11 returns unicode strings from C++ methods that return std::string; the problem was showing up in afw's `testCameraGeom.py`.
