### PR TITLE
DM-12656: Deal with new flake8 warnings

### DIFF
--- a/python/lsst/pex/config/configChoiceField.py
+++ b/python/lsst/pex/config/configChoiceField.py
@@ -222,7 +222,7 @@ class ConfigInstanceDict(collections.Mapping):
         except KeyError:
             try:
                 dtype = self._field.typemap[k]
-            except:
+            except Exception:
                 raise FieldValidationError(self._field, self._config,
                                            "Unknown key %r in Registry/ConfigChoiceField" % k)
             name = _joinNamePath(self._config._name, self._field.name, k)
@@ -238,7 +238,7 @@ class ConfigInstanceDict(collections.Mapping):
 
         try:
             dtype = self._field.typemap[k]
-        except:
+        except Exception:
             raise FieldValidationError(self._field, self._config, "Unknown key %r" % k)
 
         if value != dtype and type(value) != dtype:

--- a/python/lsst/pex/config/configurableField.py
+++ b/python/lsst/pex/config/configurableField.py
@@ -156,7 +156,7 @@ class ConfigurableField(Field):
         if ConfigClass is None:
             try:
                 ConfigClass = target.ConfigClass
-            except:
+            except Exception:
                 raise AttributeError("'target' must define attribute 'ConfigClass'")
         if not issubclass(ConfigClass, Config):
             raise TypeError("'ConfigClass' is of incorrect type %s."

--- a/python/lsst/pex/config/wrap.py
+++ b/python/lsst/pex/config/wrap.py
@@ -231,7 +231,7 @@ def makeConfigClass(ctrl, name=None, base=Config, doc=None, module=0, cls=None):
             # Indicate in the history that these values came from C++, even if we can't say which line
             self.readControl(r, __at=[(ctrl.__name__ + " C++", 0, "setDefaults", "")], __label="defaults",
                              __reset=True)
-        except:
+        except Exception:
             pass  # if we can't instantiate the Control, don't set defaults
 
     ctrl.ConfigClass = cls

--- a/tests/test_Config.py
+++ b/tests/test_Config.py
@@ -124,7 +124,7 @@ class ConfigTest(unittest.TestCase):
             self.simple.d["failKey"] = "failValue"
         except pexConfig.FieldValidationError:
             pass
-        except:
+        except Exception:
             raise "Validation error Expected"
         self.simple.validate()
 

--- a/tests/test_Config.py
+++ b/tests/test_Config.py
@@ -44,8 +44,8 @@ class Simple(pexConfig.Config):
                               allowed={"Hello": "First choice", "World": "second choice"})
     r = pexConfig.RangeField("Range test", float, default=3.0, optional=False,
                              min=3.0, inclusiveMin=True)
-    l = pexConfig.ListField("list test", int, default=[1, 2, 3], maxLength=5,
-                            itemCheck=lambda x: x is not None and x > 0)
+    ll = pexConfig.ListField("list test", int, default=[1, 2, 3], maxLength=5,
+                             itemCheck=lambda x: x is not None and x > 0)
     d = pexConfig.DictField("dict test", str, str, default={"key": "value"},
                             itemCheck=lambda x: x.startswith('v'))
     n = pexConfig.Field("nan test", float, default=float("NAN"))
@@ -100,7 +100,7 @@ class ConfigTest(unittest.TestCase):
         self.assertEqual(self.simple.f, 3.0)
         self.assertEqual(self.simple.b, False)
         self.assertEqual(self.simple.c, "Hello")
-        self.assertEqual(list(self.simple.l), [1, 2, 3])
+        self.assertEqual(list(self.simple.ll), [1, 2, 3])
         self.assertEqual(self.simple.d["key"], "value")
         self.assertEqual(self.inner.f, 0.0)
 
@@ -295,14 +295,14 @@ class ConfigTest(unittest.TestCase):
         self.assertEqual(pol.get("f"), self.simple.f)
         self.assertEqual(pol.get("b"), self.simple.b)
         self.assertEqual(pol.get("c"), self.simple.c)
-        self.assertEqual(pol.getArray("l"), list(self.simple.l))
+        self.assertEqual(pol.getArray("ll"), list(self.simple.ll))
 
         ps = pexConfig.makePropertySet(self.simple)
         self.assertEqual(ps.exists("i"), False)
         self.assertEqual(ps.get("f"), self.simple.f)
         self.assertEqual(ps.get("b"), self.simple.b)
         self.assertEqual(ps.get("c"), self.simple.c)
-        self.assertEqual(list(ps.get("l")), list(self.simple.l))
+        self.assertEqual(list(ps.get("ll")), list(self.simple.ll))
 
         pol = pexConfig.makePolicy(self.comp)
         self.assertEqual(pol.get("c.f"), self.comp.c.f)
@@ -381,7 +381,7 @@ except ImportError:
         def outFunc(msg):
             outList.append(msg)
         simple2.b = True
-        simple2.l.append(4)
+        simple2.ll.append(4)
         simple2.d["foo"] = "var"
         self.assertFalse(self.simple.compare(simple2, shortcut=True, output=outFunc))
         self.assertEqual(len(outList), 1)
@@ -389,17 +389,17 @@ except ImportError:
         self.assertFalse(self.simple.compare(simple2, shortcut=False, output=outFunc))
         output = "\n".join(outList)
         self.assertIn("Inequality in b", output)
-        self.assertIn("Inequality in size for l", output)
+        self.assertIn("Inequality in size for ll", output)
         self.assertIn("Inequality in keys for d", output)
         del outList[:]
         self.simple.d["foo"] = "vast"
-        self.simple.l.append(5)
+        self.simple.ll.append(5)
         self.simple.b = True
         self.simple.f += 1E8
         self.assertFalse(self.simple.compare(simple2, shortcut=False, output=outFunc))
         output = "\n".join(outList)
         self.assertIn("Inequality in f", output)
-        self.assertIn("Inequality in l[3]", output)
+        self.assertIn("Inequality in ll[3]", output)
         self.assertIn("Inequality in d['foo']", output)
         del outList[:]
         comp2.r["BBB"].f = 1.0  # changing the non-selected item shouldn't break equality

--- a/tests/test_configDictField.py
+++ b/tests/test_configDictField.py
@@ -44,7 +44,7 @@ class ConfigDictFieldTest(unittest.TestCase):
         try:
             class BadKeytype(pexConfig.Config):
                 d = pexConfig.ConfigDictField("...", keytype=list, itemtype=Config1)
-        except:
+        except Exception:
             pass
         else:
             raise SyntaxError("Unsupported keytypes should not be allowed")
@@ -52,7 +52,7 @@ class ConfigDictFieldTest(unittest.TestCase):
         try:
             class BadItemtype(pexConfig.Config):
                 d = pexConfig.ConfigDictField("...", keytype=int, itemtype=dict)
-        except:
+        except Exception:
             pass
         else:
             raise SyntaxError("Unsupported itemtypes should not be allowed")
@@ -60,7 +60,7 @@ class ConfigDictFieldTest(unittest.TestCase):
         try:
             class BadItemCheck(pexConfig.Config):
                 d = pexConfig.ConfigDictField("...", keytype=str, itemtype=Config1, itemCheck=4)
-        except:
+        except Exception:
             pass
         else:
             raise SyntaxError("Non-callable itemCheck should not be allowed")
@@ -68,7 +68,7 @@ class ConfigDictFieldTest(unittest.TestCase):
         try:
             class BadDictCheck(pexConfig.Config):
                 d = pexConfig.DictField("...", keytype=int, itemtype=Config1, dictCheck=4)
-        except:
+        except Exception:
             pass
         else:
             raise SyntaxError("Non-callable dictCheck should not be allowed")

--- a/tests/test_configurableField.py
+++ b/tests/test_configurableField.py
@@ -54,7 +54,7 @@ class ConfigurableFieldTest(unittest.TestCase):
         try:
             class BadTarget(pexConf.Config):
                 d = pexConf.ConfigurableField("...", target=None)
-        except:
+        except Exception:
             pass
         else:
             raise SyntaxError("Uncallable targets should not be allowed")
@@ -62,7 +62,7 @@ class ConfigurableFieldTest(unittest.TestCase):
         try:
             class NoConfigClass(pexConf.Config):
                 d = pexConf.ConfigurableField("...", target=Target2)
-        except:
+        except Exception:
             pass
         else:
             raise SyntaxError("Missing ConfigClass should not be allowed")
@@ -70,7 +70,7 @@ class ConfigurableFieldTest(unittest.TestCase):
         try:
             class BadConfigClass(pexConf.Config):
                 d = pexConf.DictField("...", target=Target2, ConfigClass=Target2)
-        except:
+        except Exception:
             pass
         else:
             raise SyntaxError("ConfigClass that are not subclasses of Config should not be allowed")

--- a/tests/test_dictField.py
+++ b/tests/test_dictField.py
@@ -38,7 +38,7 @@ class DictFieldTest(unittest.TestCase):
         try:
             class BadKeytype(pexConfig.Config):
                 d = pexConfig.DictField("...", keytype=list, itemtype=int)
-        except:
+        except Exception:
             pass
         else:
             raise SyntaxError("Unsupported keyptype DictFields should not be allowed")
@@ -46,7 +46,7 @@ class DictFieldTest(unittest.TestCase):
         try:
             class BadItemtype(pexConfig.Config):
                 d = pexConfig.DictField("...", keytype=int, itemtype=dict)
-        except:
+        except Exception:
             pass
         else:
             raise SyntaxError("Unsupported itemtype DictFields should not be allowed")
@@ -54,7 +54,7 @@ class DictFieldTest(unittest.TestCase):
         try:
             class BadItemCheck(pexConfig.Config):
                 d = pexConfig.DictField("...", keytype=int, itemtype=int, itemCheck=4)
-        except:
+        except Exception:
             pass
         else:
             raise SyntaxError("Non-callable itemCheck DictFields should not be allowed")
@@ -62,7 +62,7 @@ class DictFieldTest(unittest.TestCase):
         try:
             class BadDictCheck(pexConfig.Config):
                 d = pexConfig.DictField("...", keytype=int, itemtype=int, dictCheck=4)
-        except:
+        except Exception:
             pass
         else:
             raise SyntaxError("Non-callable dictCheck DictFields should not be allowed")

--- a/tests/test_listField.py
+++ b/tests/test_listField.py
@@ -60,7 +60,7 @@ class ListFieldTest(unittest.TestCase):
         try:
             class BadDtype(pexConfig.Config):
                 l = pexConfig.ListField("...", list)
-        except:
+        except Exception:
             pass
         else:
             raise SyntaxError("Unsupported dtype ListFields should not be allowed")
@@ -76,7 +76,7 @@ class ListFieldTest(unittest.TestCase):
         try:
             class BadLength(pexConfig.Config):
                 l = pexConfig.ListField("...", int, length=-1)
-        except:
+        except Exception:
             pass
         else:
             raise SyntaxError("negative length should not be allowed")
@@ -84,7 +84,7 @@ class ListFieldTest(unittest.TestCase):
         try:
             class BadLength2(pexConfig.Config):
                 l = pexConfig.ListField("...", int, maxLength=-1)
-        except:
+        except Exception:
             pass
         else:
             raise SyntaxError("negative max length should not be allowed")

--- a/tests/test_listField.py
+++ b/tests/test_listField.py
@@ -59,7 +59,7 @@ class ListFieldTest(unittest.TestCase):
     def testConstructor(self):
         try:
             class BadDtype(pexConfig.Config):
-                l = pexConfig.ListField("...", list)
+                ll = pexConfig.ListField("...", list)
         except Exception:
             pass
         else:
@@ -67,7 +67,7 @@ class ListFieldTest(unittest.TestCase):
 
         try:
             class BadLengths(pexConfig.Config):
-                l = pexConfig.ListField("...", int, minLength=4, maxLength=2)
+                ll = pexConfig.ListField("...", int, minLength=4, maxLength=2)
         except ValueError:
             pass
         else:
@@ -75,7 +75,7 @@ class ListFieldTest(unittest.TestCase):
 
         try:
             class BadLength(pexConfig.Config):
-                l = pexConfig.ListField("...", int, length=-1)
+                ll = pexConfig.ListField("...", int, length=-1)
         except Exception:
             pass
         else:
@@ -83,7 +83,7 @@ class ListFieldTest(unittest.TestCase):
 
         try:
             class BadLength2(pexConfig.Config):
-                l = pexConfig.ListField("...", int, maxLength=-1)
+                ll = pexConfig.ListField("...", int, maxLength=-1)
         except Exception:
             pass
         else:


### PR DESCRIPTION
* `l` variable not allowed
* bare `except`.