### PR TITLE
DM-13755: ReST-ify config doc strings

### DIFF
--- a/python/lsst/pex/config/choiceField.py
+++ b/python/lsst/pex/config/choiceField.py
@@ -55,7 +55,7 @@ class ChoiceField(Field):
             if choice is not None and not isinstance(choice, dtype):
                 raise ValueError("ChoiceField's allowed choice %s is of incorrect type %s. Expected %s" %
                                  (choice, _typeStr(choice), _typeStr(dtype)))
-            self.__doc__ += "%s\n  %s\n" % (str(choice), choiceDoc)
+            self.__doc__ += "%s\n  %s\n" % ('``{0!r}``'.format(str(choice)), choiceDoc)
 
         self.source = getStackFrame()
 

--- a/python/lsst/pex/config/choiceField.py
+++ b/python/lsst/pex/config/choiceField.py
@@ -47,15 +47,16 @@ class ChoiceField(Field):
         if dtype == str:
             dtype = oldStringType
 
-        doc += "\nAllowed values:\n"
+        Field.__init__(self, doc=doc, dtype=dtype, default=default,
+                       check=None, optional=optional)
+
+        self.__doc__ += "\n\nAllowed values:\n\n"
         for choice, choiceDoc in self.allowed.items():
             if choice is not None and not isinstance(choice, dtype):
                 raise ValueError("ChoiceField's allowed choice %s is of incorrect type %s. Expected %s" %
                                  (choice, _typeStr(choice), _typeStr(dtype)))
-            doc += "\t%s\t%s\n" % (str(choice), choiceDoc)
+            self.__doc__ += "%s\n  %s\n" % (str(choice), choiceDoc)
 
-        Field.__init__(self, doc=doc, dtype=dtype, default=default,
-                       check=None, optional=optional)
         self.source = getStackFrame()
 
     def _validateValue(self, value):

--- a/python/lsst/pex/config/config.py
+++ b/python/lsst/pex/config/config.py
@@ -192,7 +192,7 @@ class Field(object):
         """
         self.dtype = dtype
         self.doc = doc
-        self.__doc__ = doc+" (`"+dtype.__name__+"`)"
+        self.__doc__ = doc+" (`"+dtype.__name__+"`, default "+'``{0!r}``'.format(default)+")"
         self.default = default
         self.check = check
         self.optional = optional

--- a/python/lsst/pex/config/config.py
+++ b/python/lsst/pex/config/config.py
@@ -192,7 +192,7 @@ class Field(object):
         """
         self.dtype = dtype
         self.doc = doc
-        self.__doc__ = doc
+        self.__doc__ = doc+" (`"+dtype.__name__+"`)"
         self.default = default
         self.check = check
         self.optional = optional

--- a/python/lsst/pex/config/rangeField.py
+++ b/python/lsst/pex/config/rangeField.py
@@ -54,12 +54,6 @@ class RangeField(Field):
         self.min = min
         self.max = max
 
-        self.rangeString = "%s%s,%s%s" % \
-            (("[" if inclusiveMin else "("),
-             ("-inf" if self.min is None else self.min),
-             ("inf" if self.max is None else self.max),
-             ("]" if inclusiveMax else ")"))
-        doc += "\n\tValid Range = " + self.rangeString
         if inclusiveMax:
             self.maxCheck = lambda x, y: True if y is None else x <= y
         else:
@@ -69,6 +63,12 @@ class RangeField(Field):
         else:
             self.minCheck = lambda x, y: True if y is None else x > y
         self._setup(doc, dtype=dtype, default=default, check=None, optional=optional, source=source)
+        self.rangeString = "%s%s,%s%s" % \
+            (("[" if inclusiveMin else "("),
+             ("-inf" if self.min is None else self.min),
+             ("inf" if self.max is None else self.max),
+             ("]" if inclusiveMax else ")"))
+        self.__doc__ += "\n\nValid Range = " + self.rangeString
 
     def _validateValue(self, value):
         Field._validateValue(self, value)


### PR DESCRIPTION
This changes how the default Field constructor handles the `doc` argument.  It also changes how `ChoiceField` and `RangeField` handle `self.__doc__`.

Example base `Field`, `RangeField` and `ChoiceField`:
``` 
 |  doWriteExposure
 |      Write icExp and icExpBackground in addition to icSrc? Ignored if doWrite False. (`bool`)
 |  
 |  psfIterations
 |      Number of iterations of detect sources, measure sources, estimate PSF. If useSimplePsf is True then 2 should be plenty; otherwise more may be wanted. (`int`)
 |      
 |      Valid Range = [1,inf)
 |
 |  flatScalingType
 |      The method for scaling the flat on the fly. (`str`)
 |      
 |      Allowed values:
 |      
 |      USER
 |        Scale by flatUserScale
 |      MEAN
 |        Scale by the inverse of the mean
 |      MEDIAN
 |        Scale by the inverse of the median
 |      None
 |        Field is optional
```