### PR TITLE
DM-17088: Replace collections with collections.abc

### DIFF
--- a/python/lsst/pex/config/configChoiceField.py
+++ b/python/lsst/pex/config/configChoiceField.py
@@ -23,14 +23,14 @@
 __all__ = ["ConfigChoiceField"]
 
 import copy
-import collections
+import collections.abc
 
 from .config import Config, Field, FieldValidationError, _typeStr, _joinNamePath
 from .comparison import getComparisonName, compareScalars, compareConfigs
 from .callStack import getCallStack, getStackFrame
 
 
-class SelectionSet(collections.MutableSet):
+class SelectionSet(collections.abc.MutableSet):
     """
     Custom set class used to track the selection of multi-select
     ConfigChoiceField.
@@ -107,14 +107,14 @@ class SelectionSet(collections.MutableSet):
         return str(list(self._set))
 
 
-class ConfigInstanceDict(collections.Mapping):
+class ConfigInstanceDict(collections.abc.Mapping):
     """A dict of instantiated configs, used to populate a ConfigChoiceField.
 
     typemap must support the following:
     - typemap[name]: return the config class associated with the given name
     """
     def __init__(self, config, field):
-        collections.Mapping.__init__(self)
+        collections.abc.Mapping.__init__(self)
         self._dict = dict()
         self._selection = None
         self._config = config

--- a/python/lsst/pex/config/dictField.py
+++ b/python/lsst/pex/config/dictField.py
@@ -22,14 +22,14 @@
 
 __all__ = ["DictField"]
 
-import collections
+import collections.abc
 
 from .config import Field, FieldValidationError, _typeStr, _autocast, _joinNamePath
 from .comparison import getComparisonName, compareScalars
 from .callStack import getCallStack, getStackFrame
 
 
-class Dict(collections.MutableMapping):
+class Dict(collections.abc.MutableMapping):
     """
     Config-Internal mapping container
     Emulates a dict, but adds validation and provenance.

--- a/python/lsst/pex/config/listField.py
+++ b/python/lsst/pex/config/listField.py
@@ -22,14 +22,14 @@
 
 __all__ = ["ListField"]
 
-import collections
+import collections.abc
 
 from .config import Field, FieldValidationError, _typeStr, _autocast, _joinNamePath
 from .comparison import compareScalars, getComparisonName
 from .callStack import getCallStack, getStackFrame
 
 
-class List(collections.MutableSequence):
+class List(collections.abc.MutableSequence):
     def __init__(self, config, field, value, at, label, setHistory=True):
         self._field = field
         self._config = config

--- a/python/lsst/pex/config/registry.py
+++ b/python/lsst/pex/config/registry.py
@@ -22,7 +22,7 @@
 
 __all__ = ("Registry", "makeRegistry", "RegistryField", "registerConfig", "registerConfigurable")
 
-import collections
+import collections.abc
 import copy
 
 from .config import Config, FieldValidationError, _typeStr
@@ -43,7 +43,7 @@ class ConfigurableWrapper:
         return self._target(*args, **kwargs)
 
 
-class Registry(collections.Mapping):
+class Registry(collections.abc.Mapping):
     """A base class for global registries, mapping names to configurables.
 
     There are no hard requirements on configurable, but they typically create an algorithm
@@ -125,7 +125,7 @@ class Registry(collections.Mapping):
         return RegistryField(doc, self, default, optional, multi)
 
 
-class RegistryAdaptor(collections.Mapping):
+class RegistryAdaptor(collections.abc.Mapping):
     """Private class that makes a Registry behave like the thing a ConfigChoiceField expects."""
 
     def __init__(self, registry):


### PR DESCRIPTION
Fixes warning in python 3.7