### PR TITLE
DM-27519: Fix couple of issues with history handling

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,7 +38,7 @@ jobs:
         run: pytest -r a -v -n 3 --open-files
 
       - name: Install documenteer
-        run: pip install documenteer[pipelines]
+        run: pip install 'documenteer[pipelines]<0.6'
 
       - name: Build documentation
         working-directory: ./doc

--- a/python/lsst/pex/config/history.py
+++ b/python/lsst/pex/config/history.py
@@ -199,7 +199,7 @@ def format(config, name=None, writeSourceLine=True, prefix="", verbose=False):
             print(format(config, name))
 
     outputs = []
-    for value, stack, label in config.history[name]:
+    for value, stack, label in config.history.get(name, []):
         output = []
         for frame in stack:
             if frame.function in ("__new__", "__set__", "__setattr__", "execfile", "wrapper") or \
@@ -219,14 +219,15 @@ def format(config, name=None, writeSourceLine=True, prefix="", verbose=False):
 
         outputs.append([value, output])
 
-    # Find the maximum widths of the value and file:lineNo fields.
-    if writeSourceLine:
-        sourceLengths = []
-        for value, output in outputs:
-            sourceLengths.append(max([len(x[0][0]) for x in output]))
-        sourceLength = max(sourceLengths)
+    if outputs:
+        # Find the maximum widths of the value and file:lineNo fields.
+        if writeSourceLine:
+            sourceLengths = []
+            for value, output in outputs:
+                sourceLengths.append(max([len(x[0][0]) for x in output]))
+            sourceLength = max(sourceLengths)
 
-    valueLength = len(prefix) + max([len(str(value)) for value, output in outputs])
+        valueLength = len(prefix) + max([len(str(value)) for value, output in outputs])
 
     # Generate the config history content.
     msg = []

--- a/python/lsst/pex/config/wrap.py
+++ b/python/lsst/pex/config/wrap.py
@@ -34,7 +34,7 @@ import importlib
 from .config import Config, Field
 from .listField import ListField, List
 from .configField import ConfigField
-from .callStack import getCallerFrame, getCallStack
+from .callStack import getCallerFrame, getCallStack, StackFrame
 
 _dtypeMap = {
     "bool": bool,
@@ -281,8 +281,8 @@ def makeConfigClass(ctrl, name=None, base=Config, doc=None, module=None, cls=Non
             r = self.Control()
             # Indicate in the history that these values came from C++, even
             # if we can't say which line
-            self.readControl(r, __at=[(ctrl.__name__ + " C++", 0, "setDefaults", "")], __label="defaults",
-                             __reset=True)
+            self.readControl(r, __at=[StackFrame(ctrl.__name__ + " C++", 0, "setDefaults", "")],
+                             __label="defaults", __reset=True)
         except Exception:
             pass  # if we can't instantiate the Control, don't set defaults
 


### PR DESCRIPTION
History of C++ defaults was recorded in the history list as a tuple
instead of StackFrame instance, I think this was a trivial omission. Also
fixed a crash in history formatting when history is empty.