### PR TITLE
DM-32663 Assume Field is operating on Config instance

### DIFF
--- a/python/lsst/pex/config/config.py
+++ b/python/lsst/pex/config/config.py
@@ -560,10 +560,19 @@ class Field:
         value described by the field (and held by the Config instance) is
         returned.
         """
-        if instance is None or not isinstance(instance, Config):
+        if instance is None:
             return self
         else:
-            return instance._storage[self.name]
+            # try statements are almost free in python if they succeed
+            try:
+                return instance._storage[self.name]
+            except AttributeError:
+                if not isinstance(instance, Config):
+                    return self
+                else:
+                    raise AttributeError(f"Config {instance} is missing "
+                                         "_storage attribute, likely"
+                                         " incorrectly initialized")
 
     def __set__(self, instance, value, at=None, label='assignment'):
         """Set an attribute on the config instance.


### PR DESCRIPTION
In almost all cases a Field is operating on a config instance,
and there should be no need to check on every invocation of
__get__. Fallback to a check if normal operation does not
succeed.