### PR TITLE
DM-32733: Make loadFromStream actually accept file-like objects.

### DIFF
--- a/tests/test_Config.py
+++ b/tests/test_Config.py
@@ -244,33 +244,36 @@ class ConfigTest(unittest.TestCase):
         roundTrip = Complex()
         roundTrip.load("roundtrip.test")
         os.remove("roundtrip.test")
-
         self.assertEqual(self.comp.c.f, roundTrip.c.f)
         self.assertEqual(self.comp.r.name, roundTrip.r.name)
-
         del roundTrip
+
         # test saving to an open file
-        outfile = open("roundtrip.test", "w")
-        self.comp.saveToStream(outfile)
-        outfile.close()
-
+        with open("roundtrip.test", "w") as outfile:
+            self.comp.saveToStream(outfile)
         roundTrip = Complex()
-        roundTrip.load("roundtrip.test")
+        with open("roundtrip.test", "r") as infile:
+            roundTrip.loadFromStream(infile)
         os.remove("roundtrip.test")
-
         self.assertEqual(self.comp.c.f, roundTrip.c.f)
         self.assertEqual(self.comp.r.name, roundTrip.r.name)
+        del roundTrip
+
+        # test saving to a string.
+        saved_string = self.comp.saveToString()
+        roundTrip = Complex()
+        roundTrip.loadFromString(saved_string)
+        self.assertEqual(self.comp.c.f, roundTrip.c.f)
+        self.assertEqual(self.comp.r.name, roundTrip.r.name)
+        del roundTrip
 
         # test backwards compatibility feature of allowing "root" instead of
         # "config"
-        outfile = open("roundtrip.test", "w")
-        self.comp.saveToStream(outfile, root="root")
-        outfile.close()
-
+        with open("roundtrip.test", "w") as outfile:
+            self.comp.saveToStream(outfile, root="root")
         roundTrip = Complex()
         roundTrip.load("roundtrip.test")
         os.remove("roundtrip.test")
-
         self.assertEqual(self.comp.c.f, roundTrip.c.f)
         self.assertEqual(self.comp.r.name, roundTrip.r.name)
 


### PR DESCRIPTION
The documentation and symmetry with `saveToStream` suggests that file-like objects were probably supposed to work, and probably did work once, but were broken at some point (and this wasn't noticed because all production calls apparently went through `load`).

To fix this while maintaining backwards compatibility, I added a `loadFromString` and moved much of the original implementation there (just shifted around the logic to guess the filename when it isn't provided), which lets both `loadFromStream` and load delegate to that without burdening either with type dispatch they don't need.