### PR TITLE
DM-33963: Directly disable pickling of proxy objects.

### DIFF
--- a/python/lsst/pex/config/config.py
+++ b/python/lsst/pex/config/config.py
@@ -25,7 +25,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-__all__ = ("Config", "ConfigMeta", "Field", "FieldValidationError")
+__all__ = ("Config", "ConfigMeta", "Field", "FieldValidationError", "UnexpectedProxyUsageError")
 
 import copy
 import importlib
@@ -60,6 +60,12 @@ if yaml:
         YamlLoaders += (CLoader,)
     except ImportError:
         pass
+
+
+class UnexpectedProxyUsageError(TypeError):
+    """Exception raised when a proxy class is used in a context that suggests
+    it should have already been converted to the thing it proxies.
+    """
 
 
 def _joinNamePath(prefix=None, name=None, index=None):

--- a/python/lsst/pex/config/configChoiceField.py
+++ b/python/lsst/pex/config/configChoiceField.py
@@ -33,7 +33,7 @@ import weakref
 
 from .callStack import getCallStack, getStackFrame
 from .comparison import compareConfigs, compareScalars, getComparisonName
-from .config import Config, Field, FieldValidationError, _joinNamePath, _typeStr
+from .config import Config, Field, FieldValidationError, _joinNamePath, _typeStr, UnexpectedProxyUsageError
 
 
 class SelectionSet(collections.abc.MutableSet):
@@ -134,6 +134,13 @@ class SelectionSet(collections.abc.MutableSet):
 
     def __str__(self):
         return str(list(self._set))
+
+    def __reduce__(self):
+        raise UnexpectedProxyUsageError(
+            f"Proxy container for config field {self._field.name} cannot "
+            "be pickled; it should be converted to a built-in container before "
+            "being assigned to other objects or variables."
+        )
 
 
 class ConfigInstanceDict(collections.abc.Mapping):
@@ -342,6 +349,13 @@ class ConfigInstanceDict(collections.abc.Mapping):
         """
         if self._typemap is None:
             self._typemap = copy.deepcopy(self.types)
+
+    def __reduce__(self):
+        raise UnexpectedProxyUsageError(
+            f"Proxy container for config field {self._field.name} cannot "
+            "be pickled; it should be converted to a built-in container before "
+            "being assigned to other objects or variables."
+        )
 
 
 class ConfigChoiceField(Field):

--- a/python/lsst/pex/config/configurableField.py
+++ b/python/lsst/pex/config/configurableField.py
@@ -32,7 +32,7 @@ import weakref
 
 from .callStack import getCallStack, getStackFrame
 from .comparison import compareConfigs, getComparisonName
-from .config import Config, Field, FieldValidationError, _joinNamePath, _typeStr
+from .config import Config, Field, FieldValidationError, _joinNamePath, _typeStr, UnexpectedProxyUsageError
 
 
 class ConfigurableInstance:
@@ -172,6 +172,14 @@ class ConfigurableInstance:
             if at is None:
                 at = getCallStack()
             self._value.__delattr__(name, at=at, label=label)
+
+    def __reduce__(self):
+        raise UnexpectedProxyUsageError(
+            f"Proxy object for config field {self._field.name} cannot "
+            "be pickled; it should be converted to a normal `Config` instance "
+            f"via the `value` property before being assigned to other objects "
+            "or variables."
+        )
 
 
 class ConfigurableField(Field):

--- a/python/lsst/pex/config/dictField.py
+++ b/python/lsst/pex/config/dictField.py
@@ -32,7 +32,15 @@ import weakref
 
 from .callStack import getCallStack, getStackFrame
 from .comparison import compareScalars, getComparisonName
-from .config import Config, Field, FieldValidationError, _autocast, _joinNamePath, _typeStr
+from .config import (
+    Config,
+    Field,
+    FieldValidationError,
+    _autocast,
+    _joinNamePath,
+    _typeStr,
+    UnexpectedProxyUsageError,
+)
 
 
 class Dict(collections.abc.MutableMapping):
@@ -147,6 +155,13 @@ class Dict(collections.abc.MutableMapping):
             # We throw everything else.
             msg = "%s has no attribute %s" % (_typeStr(self._field), attr)
             raise FieldValidationError(self._field, self._config, msg)
+
+    def __reduce__(self):
+        raise UnexpectedProxyUsageError(
+            f"Proxy container for config field {self._field.name} cannot "
+            "be pickled; it should be converted to a built-in container before "
+            "being assigned to other objects or variables."
+        )
 
 
 class DictField(Field):

--- a/python/lsst/pex/config/listField.py
+++ b/python/lsst/pex/config/listField.py
@@ -32,7 +32,15 @@ import weakref
 
 from .callStack import getCallStack, getStackFrame
 from .comparison import compareScalars, getComparisonName
-from .config import Config, Field, FieldValidationError, _autocast, _joinNamePath, _typeStr
+from .config import (
+    Config,
+    Field,
+    FieldValidationError,
+    UnexpectedProxyUsageError,
+    _autocast,
+    _joinNamePath,
+    _typeStr,
+)
 
 
 class List(collections.abc.MutableSequence):
@@ -220,6 +228,13 @@ class List(collections.abc.MutableSequence):
             # We throw everything else.
             msg = "%s has no attribute %s" % (_typeStr(self._field), attr)
             raise FieldValidationError(self._field, self._config, msg)
+
+    def __reduce__(self):
+        raise UnexpectedProxyUsageError(
+            f"Proxy container for config field {self._field.name} cannot "
+            "be pickled; it should be converted to a built-in container before "
+            "being assigned to other objects or variables."
+        )
 
 
 class ListField(Field):

--- a/tests/test_configChoiceField.py
+++ b/tests/test_configChoiceField.py
@@ -26,6 +26,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import pickle
 import unittest
 
 import lsst.pex.config as pexConfig
@@ -146,6 +147,14 @@ class ConfigChoiceFieldTest(unittest.TestCase):
         self.config.c = ["AAA"]
         self.config.d = None
         self.config.validate()
+
+    def testNoPickle(self):
+        """Test that pickle support is disabled for the proxy container.
+        """
+        with self.assertRaises(pexConfig.UnexpectedProxyUsageError):
+            pickle.dumps(self.config.c)
+        with self.assertRaises(pexConfig.UnexpectedProxyUsageError):
+            pickle.dumps(self.config.c.names)
 
 
 if __name__ == "__main__":

--- a/tests/test_configurableField.py
+++ b/tests/test_configurableField.py
@@ -26,6 +26,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import pickle
 import unittest
 
 import lsst.pex.config as pexConf
@@ -139,6 +140,13 @@ class ConfigurableFieldTest(unittest.TestCase):
 
         self.assertEqual(c.c2.f, r.c2.f)
         self.assertEqual(c.c2.target, r.c2.target)
+
+    def testNoPickle(self):
+        """Test that pickle support is disabled for the proxy container.
+        """
+        c = Config2()
+        with self.assertRaises(pexConf.UnexpectedProxyUsageError):
+            pickle.dumps(c.c2)
 
 
 if __name__ == "__main__":

--- a/tests/test_dictField.py
+++ b/tests/test_dictField.py
@@ -25,6 +25,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import pickle
 import unittest
 
 import lsst.pex.config as pexConfig
@@ -141,6 +142,13 @@ class DictFieldTest(unittest.TestCase):
             c2.d4[k] = ""
 
         self.assertTrue(pexConfig.compareConfigs("test", c1, c2))
+
+    def testNoPickle(self):
+        """Test that pickle support is disabled for the proxy container.
+        """
+        c = Config1()
+        with self.assertRaises(pexConfig.UnexpectedProxyUsageError):
+            pickle.dumps(c.d4)
 
 
 if __name__ == "__main__":

--- a/tests/test_listField.py
+++ b/tests/test_listField.py
@@ -25,6 +25,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import pickle
 import unittest
 
 import lsst.pex.config as pexConfig
@@ -160,6 +161,13 @@ class ListFieldTest(unittest.TestCase):
     def testNoArbitraryAttributes(self):
         c = Config1()
         self.assertRaises(pexConfig.FieldValidationError, setattr, c.l1, "should", "fail")
+
+    def testNoPickle(self):
+        """Test that pickle support is disabled for the proxy container.
+        """
+        c = Config2()
+        with self.assertRaises(pexConfig.UnexpectedProxyUsageError):
+            pickle.dumps(c.ls)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Pickling of these was already broken due to weakref usage, so this is about making the error message less cryptic.