### PR TITLE
DM-34326 Collect imports in ConfigDictField

### DIFF
--- a/python/lsst/pex/config/configDictField.py
+++ b/python/lsst/pex/config/configDictField.py
@@ -213,6 +213,14 @@ class ConfigDictField(DictField):
 
         return dict_
 
+    def _collectImports(self, instance, imports):
+        # docstring inherited from Field
+        configDict = self.__get__(instance)
+        if configDict is not None:
+            for v in configDict.values():
+                v._collectImports()
+                imports |= v._imports
+
     def save(self, outfile, instance):
         configDict = self.__get__(instance)
         fullname = _joinNamePath(instance._name, self.name)

--- a/tests/test_configDictField.py
+++ b/tests/test_configDictField.py
@@ -34,6 +34,10 @@ import lsst.pex.config as pexConfig
 class Config1(pexConfig.Config):
     f = pexConfig.Field("f", float, default=3.0)
 
+    def _collectImports(self):
+        # Exists to test that imports of dict values are collected
+        self._imports.add("builtins")
+
 
 class Config2(pexConfig.Config):
     d1 = pexConfig.ConfigDictField("d1", keytype=str, itemtype=Config1, itemCheck=lambda x: x.f > 0)
@@ -113,6 +117,10 @@ class ConfigDictFieldTest(unittest.TestCase):
     def testSave(self):
         c = Config2(d1={"a": Config1(f=4)})
         c.save("configDictTest.py")
+
+        # verify _collectImports is called on all the configDictValues
+        stringOutput = c.saveToString()
+        self.assertIn("import builtins", stringOutput)
 
         rt = Config2()
         rt.load("configDictTest.py")


### PR DESCRIPTION
This commit fixes an issue where imports for modules were not being
collected from configs owned by a ConfigDictField.