### PR TITLE
DM-22802: Changes requested by the DRAGONS team

### DIFF
--- a/python/lsst/pex/config/callStack.py
+++ b/python/lsst/pex/config/callStack.py
@@ -102,7 +102,7 @@ class StackFrame:
     getStackFrame
     """
 
-    _STRIP = "/python/lsst/"
+    _STRIP = "/DRAGONS/"
     """String to strip from the ``filename`` in the constructor."""
 
     def __init__(self, filename, lineno, function, content=None):

--- a/python/lsst/pex/config/comparison.py
+++ b/python/lsst/pex/config/comparison.py
@@ -97,6 +97,8 @@ def compareScalars(name, v1, v2, output, rtol=1e-8, atol=1e-8, dtype=None):
     -----
     Floating point comparisons are performed by `numpy.allclose`.
     """
+    if isinstance(dtype, tuple):
+        dtype = type(v1)
     if v1 is None or v2 is None:
         result = v1 == v2
     elif dtype in (float, complex):

--- a/python/lsst/pex/config/config.py
+++ b/python/lsst/pex/config/config.py
@@ -109,8 +109,17 @@ def _autocast(x, dtype):
         ``dtype``. If the cast cannot be performed the original value of
         ``x`` is returned.
     """
-    if dtype == float and isinstance(x, int):
+    if isinstance(x, int) and (
+        dtype == float or (isinstance(dtype, tuple) and float in dtype and int not in dtype)
+    ):
         return float(x)
+    if isinstance(x, str):
+        for type in (int, float, bool):
+            if dtype == type or (isinstance(dtype, tuple) and type in dtype):
+                try:
+                    return type(x)
+                except ValueError:  # Carry on and try a different coercion
+                    pass
     return x
 
 
@@ -335,14 +344,19 @@ class Field:
     5
     """
 
-    supportedTypes = set((str, bool, float, int, complex, AstroData))
+    supportedTypes = set((str, bool, float, int, complex, tuple, AstroData))
     """Supported data types for field values (`set` of types).
     """
 
     _counter = itertools.count()
 
     def __init__(self, doc, dtype, default=None, check=None, optional=False, deprecated=None):
-        if dtype not in self.supportedTypes:
+        if isinstance(dtype, list):
+            dtype = tuple(dtype)
+        if isinstance(dtype, tuple):
+            if any([x not in self.supportedTypes for x in dtype]):
+                raise ValueError("Unsupported Field dtype in %s" % repr(dtype))
+        elif dtype not in self.supportedTypes:
             raise ValueError("Unsupported Field dtype %s" % _typeStr(dtype))
 
         source = getStackFrame()
@@ -487,11 +501,18 @@ class Field:
             return
 
         if not isinstance(value, self.dtype):
-            msg = "Value %s is of incorrect type %s. Expected type %s" % (
-                value,
-                _typeStr(value),
-                _typeStr(self.dtype),
-            )
+            if isinstance(self.dtype, tuple):
+                msg = "Value %s is of incorrect type %s. Expected types %s" % (
+                    value,
+                    _typeStr(value),
+                    [_typeStr(dt) for dt in self.dtype],
+                )
+            else:
+                msg = "Value %s is of incorrect type %s. Expected type %s" % (
+                    value,
+                    _typeStr(value),
+                    _typeStr(self.dtype),
+                )
             raise TypeError(msg)
         if self.check is not None and not self.check(value):
             msg = "Value %s is not a valid value" % str(value)

--- a/python/lsst/pex/config/config.py
+++ b/python/lsst/pex/config/config.py
@@ -51,6 +51,7 @@ except ImportError:
 try:
     from astrodata import AstroData
 except ImportError:
+
     class AstroData:
         pass
 
@@ -251,17 +252,8 @@ class FieldValidationError(ValueError):
         """
 
         self.configSource = config._source
-        error = (
-            "%s '%s' failed validation: %s\n"
-            "For more information see the Field definition at:\n%s"
-            " and the Config definition at:\n%s"
-            % (
-                self.fieldType.__name__,
-                self.fullname,
-                msg,
-                self.fieldSource.format(),
-                self.configSource.format(),
-            )
+        error = "{} '{}' ({}) failed validation: {}".format(
+            self.fieldType.__name__, self.fullname, field.doc, msg
         )
         super().__init__(error)
 

--- a/python/lsst/pex/config/history.py
+++ b/python/lsst/pex/config/history.py
@@ -171,7 +171,7 @@ def _colorize(text, category):
     return str(text)
 
 
-def format(config, name=None, writeSourceLine=True, prefix="", verbose=False):
+def format(config, name=None, writeSourceLine=True, prefix="", verbose=False, debug=False):
     """Format the history record for a configuration, or a specific
     configuration field.
 
@@ -190,13 +190,17 @@ def format(config, name=None, writeSourceLine=True, prefix="", verbose=False):
         even before any source line. The default is an empty string.
     verbose : `bool`, optional
         Default is `False`.
+    debug : `bool`, optional
+        Enable debug detail.
     """
-
+    msg = []
+    verbose |= debug  # verbose=False and debug=True seems wrong!
     if name is None:
         for i, name in enumerate(config.history.keys()):
             if i > 0:
-                print()
-            print(format(config, name))
+                msg.append("")
+            msg.append(format(config, name))
+        return "\n".join(msg)
 
     outputs = []
     for value, stack, label in config.history.get(name, []):
@@ -209,7 +213,7 @@ def format(config, name=None, writeSourceLine=True, prefix="", verbose=False):
                 "execfile",
                 "wrapper",
             ) or os.path.split(frame.filename)[1] in ("argparse.py", "argumentParser.py"):
-                if not verbose:
+                if not debug:
                     continue
 
             line = []
@@ -236,6 +240,9 @@ def format(config, name=None, writeSourceLine=True, prefix="", verbose=False):
                 )
 
             output.append(line)
+
+            if not verbose:
+                break
 
         outputs.append([value, output])
 

--- a/python/lsst/pex/config/listField.py
+++ b/python/lsst/pex/config/listField.py
@@ -268,6 +268,9 @@ class ListField(Field):
     deprecated : None or `str`, optional
         A description of why this Field is deprecated, including removal date.
         If not None, the string is appended to the docstring for this Field.
+    single : `bool`, optional
+        If ``single`` is `True`, a single object of ``dtype`` rather than a
+        list is okay.
 
     See also
     --------
@@ -294,6 +297,7 @@ class ListField(Field):
         minLength=None,
         maxLength=None,
         deprecated=None,
+        single=False,
     ):
         if isinstance(dtype, list):
             dtype = tuple(dtype)
@@ -323,9 +327,13 @@ class ListField(Field):
             raise ValueError("'itemCheck' must be callable")
 
         source = getStackFrame()
+        if single:
+            dtype_setup = (List,) + dtype if isinstance(dtype, tuple) else (List, dtype)
+        else:
+            dtype_setup = List
         self._setup(
             doc=doc,
-            dtype=List,
+            dtype=dtype_setup,
             default=default,
             check=None,
             optional=optional,
@@ -361,6 +369,9 @@ class ListField(Field):
         to disable checking the list's maximum length).
         """
 
+        self.single = single
+        """Control whether a single object of dtype is okay."""
+
     def validate(self, instance):
         """Validate the field.
 
@@ -386,7 +397,7 @@ class ListField(Field):
         """
         Field.validate(self, instance)
         value = self.__get__(instance)
-        if value is not None:
+        if not self.single and value is not None:
             lenValue = len(value)
             if self.length is not None and not lenValue == self.length:
                 msg = "Required list length=%d, got length=%d" % (self.length, lenValue)
@@ -409,7 +420,14 @@ class ListField(Field):
             at = getCallStack()
 
         if value is not None:
-            value = List(instance, self, value, at, label)
+            if not self.single or isinstance(value, (list, tuple)):
+                value = List(instance, self, value, at, label)
+            else:
+                value = _autocast(value, self.dtype)
+                try:
+                    self._validateValue(value)
+                except BaseException as e:
+                    raise FieldValidationError(self, instance, str(e))
         else:
             history = instance._history.setdefault(self.name, [])
             history.append((value, at, label))
@@ -432,7 +450,10 @@ class ListField(Field):
             Plain `list` of items, or `None` if the field is not set.
         """
         value = self.__get__(instance)
-        return list(value) if value is not None else None
+        if isinstance(value, List):
+            return list(value)
+        else:
+            return value
 
     def _compare(self, instance1, instance2, shortcut, rtol, atol, output):
         """Compare two config instances for equality with respect to this
@@ -476,9 +497,14 @@ class ListField(Field):
             return False
         if l1 is None and l2 is None:
             return True
+        equal = True
+        if not isinstance(l1, List):
+            if not isinstance(l2, List):
+                return compareScalars(name, l1, l2, dtype=self.dtype[1], rtol=rtol, atol=atol, output=output)
+            else:
+                return False
         if not compareScalars("size for %s" % name, len(l1), len(l2), output=output):
             return False
-        equal = True
         for n, v1, v2 in zip(range(len(l1)), l1, l2):
             result = compareScalars(
                 "%s[%d]" % (name, n), v1, v2, dtype=self.dtype, rtol=rtol, atol=atol, output=output

--- a/python/lsst/pex/config/listField.py
+++ b/python/lsst/pex/config/listField.py
@@ -295,8 +295,14 @@ class ListField(Field):
         maxLength=None,
         deprecated=None,
     ):
-        if dtype not in Field.supportedTypes:
-            raise ValueError("Unsupported dtype %s" % _typeStr(dtype))
+        if isinstance(dtype, list):
+            dtype = tuple(dtype)
+        if isinstance(dtype, tuple):
+            if any([x not in self.supportedTypes for x in dtype]):
+                raise ValueError("Unsupported Field dtype in %s" % repr(dtype))
+        elif dtype not in self.supportedTypes:
+            raise ValueError("Unsupported Field dtype %s" % _typeStr(dtype))
+
         if length is not None:
             if length <= 0:
                 raise ValueError("'length' (%d) must be positive" % length)


### PR DESCRIPTION
This is a rebased version of #44 . It's slightly different than before because python 2 is no longer supported and the code was reformatted with black. The OrderedDict usage was dropped since dict is now ordered and I also protect the AstroData import.

Obvious things we need to think about:

* How do we make the AstroData supported type something that a user can add without it being hard-coded? Knowing that AstroData.filename should be used seems wrong so we may need to think about whether `__str__` can be used or if we have a method that a new type must support.
* The python/lsst -> DRAGONS file name mangling.

cc/ @chris-simpson