### PR TITLE
DM-7148: Remove the python 2 era iterkeys, iteritems, itervalues methods

### DIFF
--- a/python/lsst/pex/config/config.py
+++ b/python/lsst/pex/config/config.py
@@ -819,90 +819,37 @@ class Config(metaclass=ConfigMeta):
 
         Returns
         -------
-        names : `list`
+        names : `dict_keys`
             List of `lsst.pex.config.Field` names.
 
         See also
         --------
         lsst.pex.config.Config.iterkeys
         """
-        return list(self._storage.keys())
+        return self._storage.keys()
 
     def values(self):
         """Get field values.
 
         Returns
         -------
-        values : `list`
-            List of field values.
-
-        See also
-        --------
-        lsst.pex.config.Config.itervalues
+        values : `dict_values`
+            Iterator of field values.
         """
-        return list(self._storage.values())
+        return self._storage.values()
 
     def items(self):
         """Get configurations as ``(field name, field value)`` pairs.
 
         Returns
         -------
-        items : `list`
-            List of tuples for each configuration. Tuple items are:
+        items : `dict_items`
+            Iterator of tuples for each configuration. Tuple items are:
 
             0. Field name.
             1. Field value.
-
-        See also
-        --------
-        lsst.pex.config.Config.iteritems
         """
-        return list(self._storage.items())
-
-    def iteritems(self):
-        """Iterate over (field name, field value) pairs.
-
-        Yields
-        ------
-        item : `tuple`
-            Tuple items are:
-
-            0. Field name.
-            1. Field value.
-
-        See also
-        --------
-        lsst.pex.config.Config.items
-        """
-        return iter(self._storage.items())
-
-    def itervalues(self):
-        """Iterate over field values.
-
-        Yields
-        ------
-        value : obj
-            A field value.
-
-        See also
-        --------
-        lsst.pex.config.Config.values
-        """
-        return iter(self.storage.values())
-
-    def iterkeys(self):
-        """Iterate over field names
-
-        Yields
-        ------
-        key : `str`
-            A field's key (attribute name).
-
-        See also
-        --------
-        lsst.pex.config.Config.values
-        """
-        return iter(self.storage.keys())
+        return self._storage.items()
 
     def __contains__(self, name):
         """!Return True if the specified field exists in this config

--- a/tests/test_Config.py
+++ b/tests/test_Config.py
@@ -535,6 +535,19 @@ except ImportError:
         for name in names:
             self.assertTrue(hasattr(self.simple, name))
 
+    def testIteration(self):
+        self.assertIn("ll", self.simple)
+        self.assertIn("ll", self.simple.keys())
+        self.assertIn("Hello", self.simple.values())
+        self.assertEqual(len(self.simple.values()), 8)
+
+        for k, v, (k1, v1) in zip(self.simple.keys(), self.simple.values(), self.simple.items()):
+            self.assertEqual(k, k1)
+            if k == "n":
+                self.assertNotEqual(v, v1)
+            else:
+                self.assertEqual(v, v1)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The keys, items, and values methods now return python 3 compliant values.