### PR TITLE
DM-35312 Add support for python typing of Fields

### DIFF
--- a/python/lsst/pex/config/configDictField.py
+++ b/python/lsst/pex/config/configDictField.py
@@ -33,7 +33,7 @@ from .config import Config, FieldValidationError, _autocast, _joinNamePath, _typ
 from .dictField import Dict, DictField
 
 
-class ConfigDict(Dict):
+class ConfigDict(Dict[str, Config]):
     """Internal representation of a dictionary of configuration classes.
 
     Much like `Dict`, `ConfigDict` is a custom `MutableMapper` which tracks

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,9 @@ tests_requires =
 [options.packages.find]
 where=python
 
+[options.package_data]
+lsst.pex.config = py.typed
+
 # The ignore list for flake8 itself when run on the command line is distinct
 # from the ignore list used by the pytest-flake8 plugin. This provides more
 # control over testing but does require that the lists are kept in sync

--- a/tests/test_Config.py
+++ b/tests/test_Config.py
@@ -115,6 +115,27 @@ class ConfigTest(unittest.TestCase):
         del self.outer
         del self.comp
 
+    def testFieldTypeAnnotationRuntime(self):
+        # test parsing type annotation for runtime dtype
+        testField = pexConfig.Field[str](doc="")
+        self.assertEqual(testField.dtype, str)
+
+        # verify that forward references work correctly
+        testField = pexConfig.Field["float"](doc="")
+        self.assertEqual(testField.dtype, float)
+
+        # verify that Field rejects multiple types
+        with self.assertRaises(ValueError):
+            pexConfig.Field[str, int](doc="")  # type: ignore
+
+        # verify that Field raises in conflict with dtype:
+        with self.assertRaises(ValueError):
+            pexConfig.Field[str](doc="", dtype=int)
+
+        # verify that Field does not raise if dtype agrees
+        testField = pexConfig.Field[int](doc="", dtype=int)
+        self.assertEqual(testField.dtype, int)
+
     def testInit(self):
         self.assertIsNone(self.simple.i)
         self.assertEqual(self.simple.f, 3.0)

--- a/tests/test_dictField.py
+++ b/tests/test_dictField.py
@@ -80,6 +80,33 @@ class DictFieldTest(unittest.TestCase):
         else:
             raise SyntaxError("Non-callable dictCheck DictFields should not be allowed")
 
+    def testFieldTypeAnnotationRuntime(self):
+        # test parsing type annotation for runtime keytype, itemtype
+        testField = pexConfig.DictField[str, int](doc="")
+        self.assertEqual(testField.keytype, str)
+        self.assertEqual(testField.itemtype, int)
+
+        # verify that forward references work correctly
+        testField = pexConfig.DictField["float", "int"](doc="")
+        self.assertEqual(testField.keytype, float)
+        self.assertEqual(testField.itemtype, int)
+
+        # verify that Field rejects single types
+        with self.assertRaises(ValueError):
+            pexConfig.DictField[int](doc="")  # type: ignore
+
+        # verify that Field raises in conflict with keytype, itemtype
+        with self.assertRaises(ValueError):
+            pexConfig.DictField[str, int](doc="", keytype=int)
+
+        with self.assertRaises(ValueError):
+            pexConfig.DictField[str, int](doc="", itemtype=str)
+
+        # verify that Field does not raise if dtype agrees
+        testField = pexConfig.DictField[int, str](doc="", keytype=int, itemtype=str)
+        self.assertEqual(testField.keytype, int)
+        self.assertEqual(testField.itemtype, str)
+
     def testAssignment(self):
         c = Config1()
         self.assertRaises(pexConfig.FieldValidationError, setattr, c, "d1", {3: 3})

--- a/ups/pex_config.table
+++ b/ups/pex_config.table
@@ -6,3 +6,4 @@ envPrepend(LSST_LIBRARY_PATH, ${PRODUCT_DIR}/lib)
 
 envPrepend(PYTHONPATH, ${PRODUCT_DIR}/python)
 envPrepend(PATH, ${PRODUCT_DIR}/bin)
+envPrepend(MYPYPATH, ${PRODUCT_DIR}/python}


### PR DESCRIPTION
Add support for specifying the type of Fields with python class
typing syntax. This will ensure the appropriate type is inferred
from a Fields __get__ method, type checking when setting with
__set__, as well as setting appropriate dtypes where applicable at
runtime.