### PR TITLE
DM-36696: Make pex.config example docs be consistently sentences

### DIFF
--- a/doc/lsst.pex.config/field-types.rst
+++ b/doc/lsst.pex.config/field-types.rst
@@ -17,7 +17,7 @@ Example of `RangeField`:
         """Parameters for controlling background estimation.
         """
         binSize = pexConfig.RangeField(
-            doc=("How large a region of the sky should be "
+            doc=("Define the region of the sky size "
                  "used for each background point."),
             dtype=int, default=256, min=10
         )
@@ -31,7 +31,7 @@ Example of `ListField` and `Config` inheritance:
         """
         subregionSize = pexConfig.ListField(
             dtype=int,
-            doc=("width, height of stack subregion size; make "
+            doc=("Width and height of stack subregion size. Make the values "
                  "small enough that a full stack of images will "
                  "fit into memory at once."),
             length=2,
@@ -97,12 +97,12 @@ Examples of `ConfigurableActionField` and `ConfigurableActionStructField` making
         """An example Config class which contains multiple `ConfigurableAction`\ s."""
 
         divideAction = pexConfig.configurableActions.ConfigurableActionField(
-            doc="A field which points to a single action"
+            doc="A field which points to a single action."
             default=ExampleAction
         )
 
         multipleDivisionActions = pexConfig.configurableActions.ConfigurableActionStructField(
-            doc="A field which acts as a struct, referring to multiple ConfigurableActions"
+            doc="A field which acts as a struct, referring to multiple ConfigurableActions."
         )
 
         def setDefaults(self):

--- a/doc/lsst.pex.config/overview.rst
+++ b/doc/lsst.pex.config/overview.rst
@@ -49,7 +49,7 @@ Here is a config class that includes five fields:
            dtype=float,
            default=1.0)
        saturatedMaskName = pexConfig.Field(
-           doc="Name of mask plane to use in saturation detection",
+           doc="Name of the mask plane to use in saturation detection.",
            dtype=str,
            default="SAT")
        flatScalingType = pexConfig.ChoiceField(
@@ -62,7 +62,7 @@ Here is a config class that includes five fields:
                "MEDIAN": "Scale by the inverse of the median",
            })
        keysToRemoveFromAssembledCcd = pexConfig.ListField(
-           doc="fields to remove from the metadata of the assembled ccd.",
+           doc="Fields to remove from the metadata of the assembled ccd.",
            dtype=str,
            default=[])
 

--- a/doc/lsst.pex.config/registry-intro.rst
+++ b/doc/lsst.pex.config/registry-intro.rst
@@ -6,21 +6,21 @@ Registry and RegistryField for configuring subtasks
 
 Example of a `RegistryField` created from a `Registry` object and use of both the `Registry.register` method and the `registerConfigurable` decorator::
 
-    psfDeterminerRegistry = pexConfig.makeRegistry("""A registry of PSF determiner factories""")
+    psfDeterminerRegistry = pexConfig.makeRegistry("""A registry of PSF determiner factories.""")
 
     class PcaPsfDeterminerConfig(pexConfig.Config):
         spatialOrder = pexConfig.Field(
-                "spatial order for PSF kernel creation", int, 2)
+                "Spatial order for PSF kernel creation.", int, 2)
         [...]
 
     @pexConfig.registerConfigurable("pca", psfDeterminerRegistry)
     class PcaPsfDeterminer(object):
         ConfigClass = PcaPsfDeterminerConfig
-            # associate this Configurable class with its Config class for use
-            # by the registry
-        def __init__(self, config, schema=None):
+            # Associate this Configurable class with its Config class for use
+            # by the registry.
+        def __init__(self, config, schema=None, **kwargs):
             [...]
-        def determinePsf(self, exposure, psfCandidateList, metadata=None):
+        def determinePsf(self, exposure, psfCandidateList, metadata=None, **kwargs):
             [...]
 
     psfDeterminerRegistry.register("shapelet", ShapeletPsfDeterminer)


### PR DESCRIPTION
Changed a few doc strings to be in sentence format/proper capitalization/punctation. 
