### PR TITLE
DM-4037: Require non-empty doc string for config parameters

### DIFF
--- a/doc/changes/DM-4037.misc.rst
+++ b/doc/changes/DM-4037.misc.rst
@@ -1,0 +1,1 @@
+There is now a requirement for configuration parameters to have a non-empty docstring.

--- a/python/lsst/pex/config/config.py
+++ b/python/lsst/pex/config/config.py
@@ -497,6 +497,9 @@ class Field(Generic[FieldTypeVar]):
         """Data type for the field.
         """
 
+        if not doc:
+            raise ValueError("Docstring is empty.")
+
         # append the deprecation message to the docstring.
         if deprecated is not None:
             doc = f"{doc} Deprecated: {deprecated}"

--- a/tests/test_Config.py
+++ b/tests/test_Config.py
@@ -117,23 +117,23 @@ class ConfigTest(unittest.TestCase):
 
     def testFieldTypeAnnotationRuntime(self):
         # test parsing type annotation for runtime dtype
-        testField = pexConfig.Field[str](doc="")
+        testField = pexConfig.Field[str](doc="test")
         self.assertEqual(testField.dtype, str)
 
         # verify that forward references work correctly
-        testField = pexConfig.Field["float"](doc="")
+        testField = pexConfig.Field["float"](doc="test")
         self.assertEqual(testField.dtype, float)
 
         # verify that Field rejects multiple types
         with self.assertRaises(ValueError):
-            pexConfig.Field[str, int](doc="")  # type: ignore
+            pexConfig.Field[str, int](doc="test")  # type: ignore
 
         # verify that Field raises in conflict with dtype:
         with self.assertRaises(ValueError):
-            pexConfig.Field[str](doc="", dtype=int)
+            pexConfig.Field[str](doc="test", dtype=int)
 
         # verify that Field does not raise if dtype agrees
-        testField = pexConfig.Field[int](doc="", dtype=int)
+        testField = pexConfig.Field[int](doc="test", dtype=int)
         self.assertEqual(testField.dtype, int)
 
     def testInit(self):
@@ -225,14 +225,16 @@ class ConfigTest(unittest.TestCase):
     def testRangeFieldConstructor(self):
         """Test RangeField constructor's checking of min, max"""
         val = 3
-        self.assertRaises(ValueError, pexConfig.RangeField, "", int, default=val, min=val, max=val - 1)
-        self.assertRaises(ValueError, pexConfig.RangeField, "", float, default=val, min=val, max=val - 1e-15)
+        self.assertRaises(ValueError, pexConfig.RangeField, "test", int, default=val, min=val, max=val - 1)
+        self.assertRaises(
+            ValueError, pexConfig.RangeField, "test", float, default=val, min=val, max=val - 1e-15
+        )
         for inclusiveMin, inclusiveMax in itertools.product((False, True), (False, True)):
             if inclusiveMin and inclusiveMax:
                 # should not raise
                 class Cfg1(pexConfig.Config):
                     r1 = pexConfig.RangeField(
-                        doc="",
+                        doc="test",
                         dtype=int,
                         default=val,
                         min=val,
@@ -241,7 +243,7 @@ class ConfigTest(unittest.TestCase):
                         inclusiveMax=inclusiveMax,
                     )
                     r2 = pexConfig.RangeField(
-                        doc="",
+                        doc="test",
                         dtype=float,
                         default=val,
                         min=val,
@@ -257,7 +259,7 @@ class ConfigTest(unittest.TestCase):
                 self.assertRaises(
                     ValueError,
                     pexConfig.RangeField,
-                    doc="",
+                    doc="test",
                     dtype=int,
                     default=val,
                     min=val,
@@ -268,7 +270,7 @@ class ConfigTest(unittest.TestCase):
                 self.assertRaises(
                     ValueError,
                     pexConfig.RangeField,
-                    doc="",
+                    doc="test",
                     dtype=float,
                     default=val,
                     min=val,
@@ -290,7 +292,7 @@ class ConfigTest(unittest.TestCase):
 
             class Cfg1(pexConfig.Config):
                 r = pexConfig.RangeField(
-                    doc="",
+                    doc="test",
                     dtype=int,
                     default=val,
                     min=minVal,
@@ -301,7 +303,7 @@ class ConfigTest(unittest.TestCase):
 
             class Cfg2(pexConfig.Config):
                 r2 = pexConfig.RangeField(
-                    doc="",
+                    doc="test",
                     dtype=float,
                     default=val,
                     min=minVal,

--- a/tests/test_Config.py
+++ b/tests/test_Config.py
@@ -175,6 +175,26 @@ class ConfigTest(unittest.TestCase):
         self.deprecation.saveToStream(stream)
         self.assertIn("config.old=5\n", stream.getvalue())
 
+    def testDocstring(self):
+        """Test that the docstring is not allowed to be empty."""
+        with self.assertRaises(ValueError):
+            pexConfig.Field("", int, default=1)
+
+        with self.assertRaises(ValueError):
+            pexConfig.RangeField("", int, default=3, min=3, max=4)
+
+        with self.assertRaises(ValueError):
+            pexConfig.DictField("", str, str, default={"key": "value"})
+
+        with self.assertRaises(ValueError):
+            pexConfig.ListField("", int, default=[1, 2, 3])
+
+        with self.assertRaises(ValueError):
+            pexConfig.ConfigField("", InnerConfig)
+
+        with self.assertRaises(ValueError):
+            pexConfig.ConfigChoiceField("", typemap=GLOBAL_REGISTRY, default="AAA")
+
     def testValidate(self):
         self.simple.validate()
 

--- a/tests/test_dictField.py
+++ b/tests/test_dictField.py
@@ -82,28 +82,28 @@ class DictFieldTest(unittest.TestCase):
 
     def testFieldTypeAnnotationRuntime(self):
         # test parsing type annotation for runtime keytype, itemtype
-        testField = pexConfig.DictField[str, int](doc="")
+        testField = pexConfig.DictField[str, int](doc="test")
         self.assertEqual(testField.keytype, str)
         self.assertEqual(testField.itemtype, int)
 
         # verify that forward references work correctly
-        testField = pexConfig.DictField["float", "int"](doc="")
+        testField = pexConfig.DictField["float", "int"](doc="test")
         self.assertEqual(testField.keytype, float)
         self.assertEqual(testField.itemtype, int)
 
         # verify that Field rejects single types
         with self.assertRaises(ValueError):
-            pexConfig.DictField[int](doc="")  # type: ignore
+            pexConfig.DictField[int](doc="test")  # type: ignore
 
         # verify that Field raises in conflict with keytype, itemtype
         with self.assertRaises(ValueError):
-            pexConfig.DictField[str, int](doc="", keytype=int)
+            pexConfig.DictField[str, int](doc="test", keytype=int)
 
         with self.assertRaises(ValueError):
-            pexConfig.DictField[str, int](doc="", itemtype=str)
+            pexConfig.DictField[str, int](doc="test", itemtype=str)
 
         # verify that Field does not raise if dtype agrees
-        testField = pexConfig.DictField[int, str](doc="", keytype=int, itemtype=str)
+        testField = pexConfig.DictField[int, str](doc="test", keytype=int, itemtype=str)
         self.assertEqual(testField.keytype, int)
         self.assertEqual(testField.itemtype, str)
 

--- a/tests/ticket2818helper/define.py
+++ b/tests/ticket2818helper/define.py
@@ -43,4 +43,4 @@ class TestConfigurable:
 
 
 class BaseConfig(Config):
-    test = ConfigurableField(target=TestConfigurable, doc="")
+    test = ConfigurableField(target=TestConfigurable, doc="test")


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
