### PR TITLE
Revert "Disable doxygen build with scons"

### DIFF
--- a/doc/SConscript
+++ b/doc/SConscript
@@ -1,0 +1,3 @@
+# -*- python -*-
+from lsst.sconsUtils import scripts
+scripts.BasicSConscript.doc()


### PR DESCRIPTION
This reverts commit e987fa42969f377e27b6b4227a1b2c8e95ab3000. The doxygen docs aren't needed for python, and do not render properly because of the change to numpydoc. We do still need docs for the C++ include file and removing doxygen completely breaks downstream documentation building where docs still assume they have access to pex_config doxygen configuration.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
