### PR TITLE
DM-40198 Allow extra local variables when loading configs

### DIFF
--- a/doc/changes/DM-40198.api.md
+++ b/doc/changes/DM-40198.api.md
@@ -1,0 +1,1 @@
+The `loadFromStream` and `loadFromString` methods now take a dictionary as an optional argument which allows specifying additional variables to use in local scope when reading configs.

--- a/tests/test_Config.py
+++ b/tests/test_Config.py
@@ -32,6 +32,7 @@ import pickle
 import re
 import tempfile
 import unittest
+from types import SimpleNamespace
 
 try:
     import yaml
@@ -370,10 +371,15 @@ class ConfigTest(unittest.TestCase):
 
         # test saving to a string.
         saved_string = self.comp.saveToString()
+        saved_string += "config.c.f = parameters.value"
+        namespace = SimpleNamespace(value=7)
+        extraLocals = {"parameters": namespace}
         roundTrip = Complex()
-        roundTrip.loadFromString(saved_string)
-        self.assertEqual(self.comp.c.f, roundTrip.c.f)
+        roundTrip.loadFromString(saved_string, extraLocals=extraLocals)
+        self.assertEqual(namespace.value, roundTrip.c.f)
         self.assertEqual(self.comp.r.name, roundTrip.r.name)
+        with self.assertRaises(ValueError):
+            roundTrip.loadFromString(saved_string, root="config", extraLocals={"config": 6})
         del roundTrip
 
     def testDuplicateRegistryNames(self):


### PR DESCRIPTION
Allow a dictionary of variables to be used in local scope when configs are loaded from a stream or string.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
