### PR TITLE
DM-49121: Make config comparison output messages more consistent.

### DIFF
--- a/doc/changes/DM-49121.feature.md
+++ b/doc/changes/DM-49121.feature.md
@@ -1,0 +1,1 @@
+Make the messages emitted by `compareConfigs` consistently start with the fully-qualified name of the config field.

--- a/python/lsst/pex/config/comparison.py
+++ b/python/lsst/pex/config/comparison.py
@@ -68,7 +68,8 @@ def compareScalars(name, v1, v2, output, rtol=1e-8, atol=1e-8, dtype=None):
     ----------
     name : `str`
         Name to use when reporting differences, typically created by
-        `getComparisonName`.
+        `getComparisonName`.  This will always appear as the beginning of any
+        messages reported via ``output``.
     v1 : object
         Left-hand side value to compare.
     v2 : object
@@ -104,7 +105,7 @@ def compareScalars(name, v1, v2, output, rtol=1e-8, atol=1e-8, dtype=None):
     else:
         result = v1 == v2
     if not result and output is not None:
-        output(f"Inequality in {name}: {v1!r} != {v2!r}")
+        output(f"{name}: {v1!r} != {v2!r}")
     return result
 
 
@@ -117,7 +118,8 @@ def compareConfigs(name, c1, c2, shortcut=True, rtol=1e-8, atol=1e-8, output=Non
     ----------
     name : `str`
         Name to use when reporting differences, typically created by
-        `getComparisonName`.
+        `getComparisonName`.  This will always appear as the beginning of any
+        messages reported via ``output``.
     c1 : `lsst.pex.config.Config`
         Left-hand side config to compare.
     c2 : `lsst.pex.config.Config`
@@ -150,22 +152,24 @@ def compareConfigs(name, c1, c2, shortcut=True, rtol=1e-8, atol=1e-8, output=Non
     `~lsst.pex.config.ConfigChoiceField` instances, *unselected*
     `~lsst.pex.config.Config` instances will not be compared.
     """
+    from .config import _typeStr
+
     assert name is not None
     if c1 is None:
         if c2 is None:
             return True
         else:
             if output is not None:
-                output(f"LHS is None for {name}")
+                output(f"{name}: None != {c2!r}.")
             return False
     else:
         if c2 is None:
             if output is not None:
-                output(f"RHS is None for {name}")
+                output(f"{name}: {c1!r} != None.")
             return False
     if type(c1) is not type(c2):
         if output is not None:
-            output(f"Config types do not match for {name}: {type(c1)} != {type(c2)}")
+            output(f"{name}: config types do not match; {_typeStr(c1)} != {_typeStr(c2)}.")
         return False
     equal = True
     for field in c1._fields.values():

--- a/python/lsst/pex/config/configDictField.py
+++ b/python/lsst/pex/config/configDictField.py
@@ -319,7 +319,7 @@ class ConfigDictField(DictField):
         name = getComparisonName(
             _joinNamePath(instance1._name, self.name), _joinNamePath(instance2._name, self.name)
         )
-        if not compareScalars(f"keys for {name}", set(d1.keys()), set(d2.keys()), output=output):
+        if not compareScalars(f"{name} (keys)", set(d1.keys()), set(d2.keys()), output=output):
             return False
         equal = True
         for k, v1 in d1.items():

--- a/python/lsst/pex/config/configurableActions/_configurableActionStructField.py
+++ b/python/lsst/pex/config/configurableActions/_configurableActionStructField.py
@@ -451,7 +451,7 @@ class ConfigurableActionStructField(Field[ActionTypeVar]):
         name = getComparisonName(
             _joinNamePath(instance1._name, self.name), _joinNamePath(instance2._name, self.name)
         )
-        if not compareScalars(f"keys for {name}", set(d1.fieldNames), set(d2.fieldNames), output=output):
+        if not compareScalars(f"{name} (fields)", set(d1.fieldNames), set(d2.fieldNames), output=output):
             return False
         equal = True
         for k, v1 in d1.items():

--- a/python/lsst/pex/config/dictField.py
+++ b/python/lsst/pex/config/dictField.py
@@ -438,11 +438,9 @@ class DictField(Field[Dict[KeyTypeVar, ItemTypeVar]], Generic[KeyTypeVar, ItemTy
         name = getComparisonName(
             _joinNamePath(instance1._name, self.name), _joinNamePath(instance2._name, self.name)
         )
-        if not compareScalars(f"isnone for {name}", d1 is None, d2 is None, output=output):
-            return False
-        if d1 is None and d2 is None:
-            return True
-        if not compareScalars(f"keys for {name}", set(d1.keys()), set(d2.keys()), output=output):
+        if d1 is None or d2 is None:
+            return compareScalars(name, d1, d2, output=output)
+        if not compareScalars(f"{name} (keys)", set(d1.keys()), set(d2.keys()), output=output):
             return False
         equal = True
         for k, v1 in d1.items():

--- a/python/lsst/pex/config/listField.py
+++ b/python/lsst/pex/config/listField.py
@@ -225,6 +225,8 @@ class List(collections.abc.MutableSequence[FieldTypeVar]):
         return str(self._list)
 
     def __eq__(self, other):
+        if other is None:
+            return False
         try:
             if len(self) != len(other):
                 return False

--- a/python/lsst/pex/config/listField.py
+++ b/python/lsst/pex/config/listField.py
@@ -499,11 +499,9 @@ class ListField(Field[List[FieldTypeVar]], Generic[FieldTypeVar]):
         name = getComparisonName(
             _joinNamePath(instance1._name, self.name), _joinNamePath(instance2._name, self.name)
         )
-        if not compareScalars(f"isnone for {name}", l1 is None, l2 is None, output=output):
-            return False
-        if l1 is None and l2 is None:
-            return True
-        if not compareScalars(f"size for {name}", len(l1), len(l2), output=output):
+        if l1 is None or l2 is None:
+            return compareScalars(name, l1, l2, output=output)
+        if not compareScalars(f"{name} (len)", len(l1), len(l2), output=output):
             return False
         equal = True
         for n, v1, v2 in zip(range(len(l1)), l1, l2, strict=True):

--- a/tests/test_Config.py
+++ b/tests/test_Config.py
@@ -544,9 +544,9 @@ except ImportError:
         del outList[:]
         self.assertFalse(self.simple.compare(simple2, shortcut=False, output=outFunc))
         output = "\n".join(outList)
-        self.assertIn("Inequality in b", output)
-        self.assertIn("Inequality in size for ll", output)
-        self.assertIn("Inequality in keys for d", output)
+        self.assertIn("b: ", output)
+        self.assertIn("ll (len): ", output)
+        self.assertIn("d (keys): ", output)
         del outList[:]
         self.simple.d["foo"] = "vast"
         self.simple.ll.append(5)
@@ -554,9 +554,9 @@ except ImportError:
         self.simple.f += 1e8
         self.assertFalse(self.simple.compare(simple2, shortcut=False, output=outFunc))
         output = "\n".join(outList)
-        self.assertIn("Inequality in f", output)
-        self.assertIn("Inequality in ll[3]", output)
-        self.assertIn("Inequality in d['foo']", output)
+        self.assertIn("f: ", output)
+        self.assertIn("ll[3]: ", output)
+        self.assertIn("d['foo']: ", output)
         del outList[:]
         comp2.r["BBB"].f = 1.0  # changing the non-selected item shouldn't break equality
         self.assertTrue(self.comp.compare(comp2))
@@ -564,9 +564,9 @@ except ImportError:
         comp2.c.f = 1.0
         self.assertFalse(self.comp.compare(comp2, shortcut=False, output=outFunc))
         output = "\n".join(outList)
-        self.assertIn("Inequality in c.f", output)
-        self.assertIn("Inequality in r['AAA']", output)
-        self.assertNotIn("Inequality in r['BBB']", output)
+        self.assertIn("c.f: ", output)
+        self.assertIn("r['AAA']", output)
+        self.assertNotIn("r['BBB']", output)
 
         # Before DM-16561, this incorrectly returned `True`.
         self.assertFalse(self.inner.compare(self.outer))


### PR DESCRIPTION
The goal here is to let downstream code filter unimportant messages by looking at the prefix, which is now always the fully-qualified field name.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
